### PR TITLE
group: Fix `user already exists in group` false positive.

### DIFF
--- a/services/group.go
+++ b/services/group.go
@@ -40,13 +40,13 @@ func SubscribeUserToGroup(userID, groupID string) (models.UserGroup, error) {
 		return userGroup, existingGroup.Error
 	}
 
-	userExistInGroup := db.DB.Where(&models.UserGroup{
-		UserID: userID,
-	}).First(&userGroup)
+	userExistInGroup := db.DB.Where(&userGroup).Limit(1).Find(&models.UserGroup{})
 
-	fmt.Println(userExistInGroup.Error)
+	if userExistInGroup.Error != nil {
+		return userGroup, userExistInGroup.Error
+	}
 
-	if userExistInGroup.Error == nil {
+	if userExistInGroup.RowsAffected > 0 {
 		return userGroup, fmt.Errorf("user already exists in group")
 	}
 


### PR DESCRIPTION
The current implementation only searches if the user id is already in the user_groups table and then returns `user already exists in group` as an error.