### PR TITLE
fix(bug): changed the user events foreign key to use the correct field name

### DIFF
--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -12,7 +12,7 @@ type User struct {
 	Avatar string `gorm:"column:avatar" json:"avatar"`
 
 	// Events Relationship
-	Events           []Event     `json:"-" gorm:"foreignKey:Creator"`
+	Events           []Event     `json:"-" gorm:"foreignKey:CreatorId"`
 	InterestedEvents []Event     `json:"-" gorm:"many2many:interested_events;"`
 	UserGroup        []UserGroup `json:"-" gorm:"foreignkey:UserID;association_foreignkey:ID"`
 }


### PR DESCRIPTION

## ⚠️ this bug is only reproduced during a fresh migration

![sql_syntax_error](https://github.com/hngx-org/Demerzel-events-backend/assets/71889751/9ec3a90e-7f7b-43b6-b72c-16d94d984637)
 


## Steps to reproduce bug:
- drop the database you're using for this project 
```sql
DROP DATABASE DATABASE_NAME;
```
- create a new one
```sql
CREATE DATABASE DATABASE_NAME;
```
- spin up the server 
```bash
go run main.go
```

## Solution
had to change the foreign key for the `Events` field in the `User` struct  to match with the `CreatorId` in the `Event` struct