### PR TITLE
add image upload to create group

### DIFF
--- a/internal/models/group.go
+++ b/internal/models/group.go
@@ -10,6 +10,7 @@ import (
 type Group struct {
 	ID        string      `json:"id" gorm:"primaryKey;type:varchar(255)"`
 	Name      string      `json:"name" validate:"required"`
+	Image 	  string       `json:"image" validate:"required"`
 	CreatedAt time.Time   `json:"created_at"`
 	UpdatedAt time.Time   `json:"updated_at"`
 	Members   []UserGroup `json:"members" gorm:"foreignkey:GroupID;association_foreignkey:ID"`

--- a/services/group.go
+++ b/services/group.go
@@ -138,7 +138,7 @@ func GetGroupsByUserId(userId string) ([]models.Group, int, error) {
 	}
 
 	return groups, http.StatusOK, nil
-
+}
 func DeleteGroup(tx *gorm.DB, id string) error {
 
 	// Delete group with specified id.


### PR DESCRIPTION
[](This PR adds image upload capabilities to `createGroup` service. 

The frontend should make use of the `multipart/form-data` specification when calling this endpoint. The image is upload is optional but the request must use the `multipart/form-data` specification

see [RFC2387](https://www.rfc-editor.org/rfc/rfc2387) for more info

the form data should take a sample format of 
```js
    {
        file: <The file upload from the users device>,
        jsonData: {
            "name" : "The name of the group"
        }
    }
```
`content-type`: `multipart/form-data`

)