### PR TITLE
add image upload to create group

### DIFF
--- a/api/routes.go
+++ b/api/routes.go
@@ -38,12 +38,12 @@ func BuildRoutesHandler() *gin.Engine {
 	// Group routes
 	apiRoutes.POST("/groups", handlers.CreateGroup)
 	apiRoutes.GET("/groups", handlers.ListGroups)
-	apiRoutes.GET("groups/user", handlers.GetUserGroups)
+	// apiRoutes.GET("groups/user", handlers.GetUserGroups)
 	apiRoutes.PUT("/groups/:id", handlers.UpdateGroup)
 	apiRoutes.GET("/groups/:id", handlers.GetGroupById)
 	apiRoutes.POST("/groups/:id/subscribe", handlers.SubscribeUserToGroup)
 	apiRoutes.POST("/groups/:id/unsubscribe", handlers.UnsubscribeFromGroup)
-	apiRoutes.PUT("/groups/:id", handlers.UpdateGroup)
+	// apiRoutes.PUT("/groups/:id", handlers.UpdateGroup)
 	apiRoutes.GET("groups/user", handlers.GetUserGroups)
 	apiRoutes.DELETE("/groups/:id", handlers.DeleteGroup)
 

--- a/internal/models/group.go
+++ b/internal/models/group.go
@@ -10,6 +10,7 @@ import (
 type Group struct {
 	ID        string      `json:"id" gorm:"primaryKey;type:varchar(255)"`
 	Name      string      `json:"name" validate:"required"`
+	Image     string      `json:"image"`
 	CreatedAt time.Time   `json:"created_at"`
 	UpdatedAt time.Time   `json:"updated_at"`
 	Members   []UserGroup `json:"members" gorm:"foreignkey:GroupID;association_foreignkey:ID"`

--- a/services/group.go
+++ b/services/group.go
@@ -138,7 +138,7 @@ func GetGroupsByUserId(userId string) ([]models.Group, int, error) {
 	}
 
 	return groups, http.StatusOK, nil
-
+}
 func DeleteGroup(tx *gorm.DB, id string) error {
 
 	// Delete group with specified id.


### PR DESCRIPTION
This PR adds image upload capabilities to `createGroup` service. 

The frontend should make use of the `multipart/form-data` specification when calling this endpoint. The image is upload is optional but the request must use the `multipart/form-data` specification

see [RFC2387](https://www.rfc-editor.org/rfc/rfc2387) for more info

the form data should take a sample format of 
```js
    {
        file: <The file upload from the users device>,
        jsonData: {
            "name" : "The name of the group"
        }
    }
```

`content-type`: `multipart/form-data`

Example Test
<img width="1280" alt="Screenshot 2023-09-22 at 13 06 47" src="https://github.com/hngx-org/Demerzel-events-backend/assets/86890896/06f78cf8-491f-4f53-a423-730ccae0746b">

<img width="1280" alt="Screenshot 2023-09-22 at 13 32 12" src="https://github.com/hngx-org/Demerzel-events-backend/assets/86890896/567c37f7-b30c-4003-a0f4-7227160e33d9">



